### PR TITLE
SEARCH-9527: Add initial pipeline files

### DIFF
--- a/ci/cribl/jenkins/Jenkinsfile
+++ b/ci/cribl/jenkins/Jenkinsfile
@@ -1,0 +1,50 @@
+final String WORKSPACE_PATH = '/home/jenkins/agent/workspace'
+
+pipeline {
+  agent {
+    kubernetes {
+      cloud 'k8s-devops'
+      yamlFile 'ci/cribl/jenkins/podspec.yml'
+      defaultContainer 'builder'
+      customWorkspace WORKSPACE_PATH
+      workingDir WORKSPACE_PATH
+    }
+  }
+
+  environment {
+    BUILD_DIR = "${WORKSPACE_PATH}/build"
+  }
+
+  options {
+    ansiColor('xterm')
+    copyArtifactPermission("*")
+    disableRestartFromStage()
+  }
+
+  stages {
+
+    stage('Setup') {
+      steps {
+        script {
+          sh 'ci/cribl/scripts/setup.sh'
+        }
+      }
+    }
+
+    stage('Build ClickHouse') {
+      steps {
+        script {
+          sh "ci/cribl/scripts/build.sh"
+        }
+      }
+    }
+
+    stage('Deploy') {
+      steps {
+        script {
+          sh "ci/cribl/scripts/deploy.sh"
+        }
+      }
+    }
+  }
+}

--- a/ci/cribl/jenkins/Jenkinsfile
+++ b/ci/cribl/jenkins/Jenkinsfile
@@ -42,7 +42,9 @@ pipeline {
     stage('Deploy') {
       steps {
         script {
-          sh "ci/cribl/scripts/deploy.sh"
+          withCredentials([string(credentialsId: 'STAGING_BUCKET', variable: 'S3_BUCKET')]) {
+            sh "ci/cribl/scripts/deploy.sh"
+          }
         }
       }
     }

--- a/ci/cribl/jenkins/podspec.yml
+++ b/ci/cribl/jenkins/podspec.yml
@@ -1,0 +1,36 @@
+kind: Pod
+metadata:
+  name: jenkins-agent
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+  labels:
+    cribl.io/cluster: "k8s-devops"
+    cribl.io/environment: "aws"
+    cribl.io/platform: "linux"
+    cribl.io/arch: "arm64"
+spec:
+  nodeSelector:
+    cribl.io/instance-type: "c7g.8xlarge"
+  containers:
+    - name: builder
+      image: clickhouse/binary-builder:c9ab730d9265dda4ddbc
+      command:
+        - sleep
+      args:
+        - 99d
+      env:
+        - name: DOCKER_TLS_CERTDIR
+          value: ''
+      volumeMounts:
+        - name: docker-graph-storage
+          mountPath: /var/lib/docker
+      resources:
+        requests:
+          memory: "55Gi"
+          cpu: "31000m"
+  imagePullSecrets:
+  - name: regcred
+  terminationGracePeriodSeconds: 0
+  volumes:
+    - name: docker-graph-storage
+      emptyDir: {}

--- a/ci/cribl/scripts/build.sh
+++ b/ci/cribl/scripts/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+
+CORES=$(nproc)
+
+cmake -S . -B ${BUILD_DIR} -DNO_ARMV81_OR_HIGHER=1 -DCMAKE_BUILD_TYPE=Release -DPARALLEL_LINK_JOBS=${CORES}
+(cd build && ninja -j ${CORES} clickhouse-server clickhouse-client)

--- a/ci/cribl/scripts/deploy.sh
+++ b/ci/cribl/scripts/deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -ex
+
+S3_PREFIX="s3://io.cribl.cdn.staging/cribl-search/clickhouse"
+
+PROGRAMS_DIR="${BUILD_DIR}/programs"
+TARBALL="clickhouse.tgz"
+TARBALL_PATH="${WORKSPACE}/${TARBALL}"
+COMMIT="$(git rev-parse HEAD)"
+
+# compress the binary and linked files
+(
+  cd ${PROGRAMS_DIR}
+  tar -czf ${TARBALL_PATH} clickhouse*
+)
+
+# checksums
+(
+  cd ${WORKSPACE}
+  md5sum ${TARBALL} > ${TARBALL}.md5
+  sha256sum ${TARBALL} > ${TARBALL}.sha256
+)
+
+# copy to S3
+for f in $(ls ${TARBALL}*)
+do
+  aws s3 cp ${f} ${S3_PREFIX}/${COMMIT}/
+done

--- a/ci/cribl/scripts/deploy.sh
+++ b/ci/cribl/scripts/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-S3_PREFIX="s3://io.cribl.cdn.staging/cribl-search/clickhouse"
+S3_PREFIX="s3://${S3_BUCKET}/cribl-search/clickhouse"
 
 PROGRAMS_DIR="${BUILD_DIR}/programs"
 TARBALL="clickhouse.tgz"

--- a/ci/cribl/scripts/setup.sh
+++ b/ci/cribl/scripts/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+git config --global --add safe.directory ${WORKSPACE}
+
+# need the AWS CLI to make things easier..
+curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install
+
+git submodule update --init -j $(nproc)


### PR DESCRIPTION
Added the following:
- jenkins' pipeline file
- setup, build, and deploy scripts

Artifacts:
- `clickhouse.tgz`
- `clickhouse.tgz.md5`
- `clickhouse.tgz.sha256`

The jenkins' job has been configured on jenkins under `cribl-search` -> `clickhouse`. It currently builds in ~30mins from start to finish.

Currently using the commit as a means to track the "version" of the binary and was thinking we could store the "version" in the `package.json` in the cribl repo; which we would then pass to the AMI pipeline job and it can go fetch it from S3.

The artifacts will be deployed to an S3 prefix; e.g `<S3 prefix>/<commit>/<artifact>`
